### PR TITLE
If output format is not specified, try to determine format from the original file extension

### DIFF
--- a/core/components/phpthumbof/elements/snippets/snippet.phpthumbof.php
+++ b/core/components/phpthumbof/elements/snippets/snippet.phpthumbof.php
@@ -50,7 +50,22 @@ foreach ($eoptions as $opt) {
         $ptOptions[$opt[0]] = $opt[1];
     }
 }
-if (empty($ptOptions['f'])) $ptOptions['f'] = 'png';
+if (empty($ptOptions['f'])){
+    $ext = pathinfo($input, PATHINFO_EXTENSION);
+    $ext = strtolower($ext);
+    switch ($ext) {
+        case 'jpg':
+        case 'jpeg':
+        case 'png':
+        case 'gif':
+        case 'bmp':
+            $ptOptions['f'] = $ext;
+            break;
+        default:
+            $ptOptions['f'] = 'jpeg';
+            break;
+    }
+}
 
 /* load phpthumb */
 $assetsPath = $modx->getOption('phpthumbof.assets_path',$scriptProperties,$modx->getOption('assets_path').'components/phpthumbof/');


### PR DESCRIPTION
We found when using phpthumbof, if we did not specify the output format it would default to png, which was generating some large image files. For example we had a 100kb jpeg that was coming out as a 1mb png. When I switched the output format to jpeg it became a 26kb file. So I updated the script to attempt to get the extension from the filename and if it matches jpeg,jpg,gif,png,bmp use the respective output format.

I'm unsure if there's a reason behind setting png as the default type, the only thing I could think of was to account for transparent images, so I went with jpeg as the default if the extension cannot be pulled from the filename, or if it does not match jpeg, jpg, gif, png or bmp.
