### PR TITLE
Implemented a system event just before initializing the image render

### DIFF
--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -135,6 +135,21 @@ foreach ($settings as $setting) {
 $modx->log(modX::LOG_LEVEL_INFO,'Packaged in '.count($settings).' System Settings.'); flush();
 unset($settings,$setting,$attributes);
 
+/* load system events */
+$events = include_once $sources['data'].'transport.events.php';
+if (!is_array($events)) $modx->log(modX::LOG_LEVEL_FATAL,'No events returned.');
+$attributes= array(
+    xPDOTransport::UNIQUE_KEY => 'name',
+    xPDOTransport::PRESERVE_KEYS => true,
+    xPDOTransport::UPDATE_OBJECT => false,
+);
+foreach ($events as $event) {
+    $vehicle = $builder->createVehicle($event,$attributes);
+    $builder->putVehicle($vehicle);
+}
+$modx->log(modX::LOG_LEVEL_INFO,'Packaged in '.count($events).' System Evemts.'); flush();
+unset($events,$event,$attributes);
+
 /* now pack in the license file, readme and setup options */
 $builder->setPackageAttributes(array(
     'license' => file_get_contents($sources['docs'] . 'license.txt'),

--- a/_build/data/transport.events.php
+++ b/_build/data/transport.events.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * phpThumbOf
+ *
+ * Copyright 2009-2012 by Shaun McCormick <shaun@modx.com>
+ *
+ * phpThumbOf is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * phpThumbOf is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * phpThumbOf; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * @package phpthumbof
+ */
+/**
+ * @package phpthumbof
+ * @subpackage build
+ */
+$events = array();
+
+$events[1]= $modx->newObject('modEvent');
+$events[1]->fromArray(array(
+    'id' => 1,
+    'event' => 'OnPhpThumbOfInit',
+    'service' => 1,
+    'groupname' => 'phpThumbOf',
+));
+
+return $events;

--- a/core/components/phpthumbof/model/phpthumbof/phpthumbof.class.php
+++ b/core/components/phpthumbof/model/phpthumbof/phpthumbof.class.php
@@ -200,6 +200,9 @@ class ptThumbnail {
      * Startup the phpThumb service. Must run setInput and setOptions first.
      */
     public function initializeService() {
+		$this->modx->invokeEvent('OnPhpThumbOfInit', array(
+			'ptThumbnail' => $this
+		));
         $this->phpThumb->config = array_merge($this->phpThumb->config,$this->options);
         $this->phpThumb->initialize();
         $this->phpThumb->setParameter('config_cache_directory',$this->config['cachePath']);


### PR DESCRIPTION
To can hook on it for a "style-based" component

PLEASE READ:

The idea is to create a component for making style-based image-scaling possible. This is intended for SEO purposes and high configurable trough a custom manager page. The new call will be;

<pre>[[*imageTVname:phpthumbof=`style=blog`]]</pre>


The image will be saved in;

assets/components/phpthumbof/cache/blog/

Without any hashes (the plugin will set "phpthumbof.postfix_property_hash" to false).

You can also setup a custom URL path for every single style. Like "i/blog/".
The image URL returned will be "***/i/blog/image.jpg".
With one line of htaccess code you can redirect this back to the cache map of phpthumbof.

A single style will contain the phpthumb properties like "w=100" and "h=75". Even can make it easy to add watermarks and grayscales etc. (basically every property is possible), all setable trough the manager interface.

The plugin provided with this custom component will hook in on the event added in this pull request and will checkup the custom database table(s) to find the provided stylename and pass the properties trough to phpthumbof object.

Hope this is clear enough. I even can let you see how things work, because I have tested it already! And it works very very great! Please contact me if you have any questions
