### PR TITLE
Update core/components/phpthumbof/model/phpthumbof/phpthumbof.class.php

### DIFF
--- a/core/components/phpthumbof/model/phpthumbof/phpthumbof.class.php
+++ b/core/components/phpthumbof/model/phpthumbof/phpthumbof.class.php
@@ -219,8 +219,6 @@ class ptThumbnail {
         /* get absolute url of image */
         if (strpos($input,'/') != 0 && strpos($input,'http') != 0) {
             $input = $this->modx->context->getOption('base_url').$input;
-        } else {
-            $input = urldecode($input);
         }
 
         $hasQuery = strpos($input,'?');


### PR DESCRIPTION
urldecode should be left down to the user and not automatically done, this
has caused me so much trouble as I was using urlencode in order to fix spaces
in url but phpthumb would fail when it tries to do file_get_contents on line
3210 of phpthumb.class.php https://github.com/modxcms/revolution/blob/develop/core/model/phpthumb/phpthumb.class.php#L3210
