### PR TITLE
Update core/components/phpthumbof/model/phpthumbof/phpthumbof.class.php

### DIFF
--- a/core/components/phpthumbof/model/phpthumbof/phpthumbof.class.php
+++ b/core/components/phpthumbof/model/phpthumbof/phpthumbof.class.php
@@ -289,6 +289,7 @@ class ptThumbnail {
             $inputSanitized = str_replace(array(':','/'),'_',$this->input);
             $this->cacheFilename = md5($inputSanitized);
             $this->cacheFilename .= '.'.md5(serialize($this->options));
+            $this->cacheFilename .= '.'.filemtime(rtrim($this->modx->getOption('base_path',null,MODX_BASE_PATH),'/').$this->input);
             $this->cacheFilename .= '.' . (!empty($this->options['f']) ? $this->options['f'] : 'png');
         } else { /* or attempt to preserve the filename */
             $inputSanitized = str_replace(array('http://','https://','ftp://','sftp://'),'',$this->input);
@@ -304,6 +305,7 @@ class ptThumbnail {
                     }
                 }
                 $this->cacheFilename .= '.'.md5(serialize($this->options)).$this->modx->resource->get('id');
+                $this->cacheFilename .= '.'.filemtime(rtrim($this->modx->getOption('base_path',null,MODX_BASE_PATH),'/').$this->input);
                 $this->cacheFilename .= '.' . (!empty($this->options['f']) ? $this->options['f'] : 'png');
             }
         }


### PR DESCRIPTION
Updating an image by just "overwriting" it had no effect because the phpThumbOf cache does not care about the date, only about the filename. With this little modification an image can easily be updated by overwriting it without any need to check on all the places this image was used (and refresh the cache for those).
This code was originally written by Mark Horstmann (Thanks to @itWilllBeOK) for an older version of phpThumbOf but still should work:
// mod: add mtime to cachename
$this->cacheFilename .= '.'.filemtime(rtrim($this->modx->getOption('base_path',null,MODX_BASE_PATH),'/').$this->input);

cheers
Oliver
