### PR TITLE
Fix bug on clearing cache.

### DIFF
--- a/core/components/phpthumbof/elements/plugins/plugin.phpthumbofcachemanager.php
+++ b/core/components/phpthumbof/elements/plugins/plugin.phpthumbofcachemanager.php
@@ -40,7 +40,7 @@ switch ($modx->event->name) {
         $cacheDir = $assetsPath.'cache/';
 
         /* clear local cache */
-        if (!empty($cacheDir)) {
+        if (is_dir($cacheDir) && !empty($cacheDir)) {
             /** @var DirectoryIterator $file */
             foreach (new DirectoryIterator($cacheDir) as $file) {
                 if (!$file->isFile()) continue;


### PR DESCRIPTION
If phpthumbof is installed but never used, the cache folder is not created (so it seems), therefore the event OnSiteRefresh fails as phpthumbof attempts to parse that folder.

That quick fix should prevent that.

Thanks,
## 

Emmanuel
