### PR TITLE
Fixing CURLOPT_SSL_VERIFYHOST value

### DIFF
--- a/core/components/phpthumbof/model/aws/lib/requestcore/requestcore.class.php
+++ b/core/components/phpthumbof/model/aws/lib/requestcore/requestcore.class.php
@@ -474,7 +474,7 @@ class RequestCore
 		curl_setopt($curl_handle, CURLOPT_FILETIME, true);
 		curl_setopt($curl_handle, CURLOPT_FRESH_CONNECT, false);
 		curl_setopt($curl_handle, CURLOPT_SSL_VERIFYPEER, false);
-		curl_setopt($curl_handle, CURLOPT_SSL_VERIFYHOST, true);
+		curl_setopt($curl_handle, CURLOPT_SSL_VERIFYHOST, 2);
 		curl_setopt($curl_handle, CURLOPT_CLOSEPOLICY, CURLCLOSEPOLICY_LEAST_RECENTLY_USED);
 		$safeMode = @ini_get('safe_mode');
         $openBasedir = @ini_get('open_basedir');


### PR DESCRIPTION
This commit is fixing "CURLOPT_SSL_VERIFYHOST no longer accepts the value 1, value 2 will be used instead" notice spam. There is also some warnings about CURLOPT_CLOSEPOLICY, but this one, I guess, needs to be reviewed.
