### PR TITLE
Fix cacheFilename

### DIFF
--- a/core/components/phpthumbof/model/phpthumbof/phpthumbof.class.php
+++ b/core/components/phpthumbof/model/phpthumbof/phpthumbof.class.php
@@ -303,7 +303,7 @@ class ptThumbnail {
                         $this->cacheFilename = substr($this->cacheFilename,0,$cut);
                     }
                 }
-                $this->cacheFilename .= '.'.md5(serialize($this->options)).$this->modx->resource->get('id');
+                $this->cacheFilename .= '.'.md5(serialize($this->options).$inputSanitized).$this->modx->resource->get('id');
                 $this->cacheFilename .= '.' . (!empty($this->options['f']) ? $this->options['f'] : 'png');
             }
         }


### PR DESCRIPTION
If hashing is disabled in the settings and we use several images with the same file name, they will have the same thumbnail.

For example:
I am created news with small image gallery. In the template, I make the output of the miniatures as follows:
I bring out a preview of the news, and below, on the same page, I display gallery previews.
`[[+tv.itemImageCover:phpthumbof='w=320&far=1']]`
`<!-- some text -->`
`[[+tv.galleryImageCover:phpthumbof='w=320&far=1']]`
Image for the news I uploaded to the folder `/assets/images/items/` and named `itemname-photo-1.jpg`
Image for the gallery I uploaded to the folder `/assets/images/gallery/` and named `itemname-photo-1.jpg`

As a result, I get the same name for a thumbnail, for different images.

This pool request suggests taking into account in the hash miniatures the path to the original image.